### PR TITLE
Restore to TidyTues post with interactive graph in iframe

### DIFF
--- a/_posts/2024-12-27-tidy-tues-spells.md
+++ b/_posts/2024-12-27-tidy-tues-spells.md
@@ -8,7 +8,6 @@ image: "/assets/images/dnd/thumnail.png"
 <iframe src="{{ '/assets/images/dnd/spells_wide.html' | relative_url }}" 
         width="1000px" 
         height="900px" 
-        style="border:none;">
+        style="position: relative; transform: translateX(-175px); border:none;">
 </iframe>
 </body>
-

--- a/_site/2024/05/01/sample-post.html
+++ b/_site/2024/05/01/sample-post.html
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:74cb9643bcd3eac4a22cdd00f6d31f1e779abe367053c75a7e1a0f79b4ac2ffd
-size 1674

--- a/_site/2024/10/25/chess-1.html
+++ b/_site/2024/10/25/chess-1.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:efdb28f3acf7d5ea8ae6b86c54f12110816ad786242c3d26300ee94e842c1ced
-size 4592
+oid sha256:ac91e7f8aad36c61c41a9bd2eef2f12aa09103779bf437371c0b56ebdb4fe073
+size 4550

--- a/_site/2024/11/14/markdown-reference.html
+++ b/_site/2024/11/14/markdown-reference.html
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4aa2f24c4b3c4dddb9b7f5579c7499d82e723beef00f1066419a9db46ba7ab6d
-size 4821

--- a/_site/2024/11/23/chess-federations.html
+++ b/_site/2024/11/23/chess-federations.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:67b9c67f39fa984cf348e0ca298b4f2e319cbd026263ed220336a8b00355de70
-size 2193
+oid sha256:6abbf52eb30eb07143f968a9adca6c36b04e9c37664d007d8d9a1f5496e3f491
+size 2151

--- a/_site/2024/11/23/ding-gukesh.html
+++ b/_site/2024/11/23/ding-gukesh.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:22598b56cb1e39a542e658ffb274142cdaf77b874389e3996cbbaf4b5872326d
-size 1746
+oid sha256:ffc072f895a9d6b1c35253944849b2d606dc001aa2d0d2fd836ecc8d0a0b30fc
+size 1704

--- a/_site/2024/12/07/ding-gukesh2.html
+++ b/_site/2024/12/07/ding-gukesh2.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d50c99606f123db2f1dae6ddda7c4deecc5f1ce6ded01c248702ef34a9043344
-size 1773
+oid sha256:57f2340448ee881e49fd7b2e8c4409d0d610fce83eef188dc3911899bb3b8dfa
+size 1731

--- a/_site/2024/12/13/dnd-post.html
+++ b/_site/2024/12/13/dnd-post.html
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1e778466c1e37dc5fae57fc57d3b7b2f31fd7ec648247743f1078d64563afbca
-size 1797

--- a/_site/2024/12/27/tidy-tues-spells.html
+++ b/_site/2024/12/27/tidy-tues-spells.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5e77f459d6e8fecb36f8979a0395ac9a060db1f15acaf784d717d7e3d74c2b1f
-size 1824
+oid sha256:41225033ab18725e0b3f6906bed6770eef1ad2915850af3ab27b9849be57a592
+size 1832

--- a/_site/about.html
+++ b/_site/about.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1cfd35d652c63e48df23bf848aee8fdbfa6b5dd730e1fb41eb3efed45a6f6d7d
-size 1907
+oid sha256:99dc94cf3422c76abd1cfe58fd266fe35bdc57fd65347a8be92eb53d7d9e79e4
+size 1870

--- a/_site/assets/css/styles.css
+++ b/_site/assets/css/styles.css
@@ -1,6 +1,5 @@
 :root {
   --max-page-width: 650px;
-  --wide-page-width: 1000px;
   /* The following colors have AAA contrast with white background if font size >18px or 14px and bold */
   --primary-blue: #016d77;
   --visited: #754263;
@@ -25,16 +24,6 @@ body {
   width: 100%;
   margin: auto; /* Centers the website content within the browser */
   display: flex; /* Flex layout allows easier control over the layout */
-  flex-direction: column; /* Stacks elements in the body vertically - helps align footer at bottom of page */
-  min-height: 100vh;
-  padding: 0 20px;
-}
-
-/* Container for wider content */
-body.wide-content {
-  max-width: var(--wide-page-width); /* Remove the limit */
-  width: 100%; /* Ensures the div spans the full width of its container */
-  display: flex; /* Use flexbox for alignment */
   flex-direction: column; /* Stacks elements in the body vertically - helps align footer at bottom of page */
   min-height: 100vh;
   padding: 0 20px;

--- a/_site/index.html
+++ b/_site/index.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6c3597c21caf32d3cc19480c8a9479f150e5acaaa0ea61678573e54ca45f8e90
-size 4809
+oid sha256:f2cfa936f3147557b42917a613a0a50c004b177e8976c3bb3880b5a65ea268d6
+size 3591


### PR DESCRIPTION
Branch made from repo code at the "spells post" commit. 

Removed wide-content css as it wasn't working, created temporary inline CSS to center iframe in page.